### PR TITLE
feat: BottomNavigationBar 추가

### DIFF
--- a/lib/common/components/bottom_nav/twelfth_bottom_nav_bar.dart
+++ b/lib/common/components/bottom_nav/twelfth_bottom_nav_bar.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:twelfth_mobile/constants/color.dart';
+import 'package:twelfth_mobile/constants/text_style.dart';
+
+class TwelfthBottomNavBar extends StatelessWidget {
+  final int currentIndex;
+  final ValueChanged<int> onTap;
+
+  const TwelfthBottomNavBar({
+    super.key,
+    required this.currentIndex,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(color: CustomColor.background),
+      child: SafeArea(
+        child: SizedBox(
+          height: 56,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              _buildNavItem(0, Symbols.leaderboard, '랭킹'),
+              _buildNavItem(1, Symbols.search, '검색'),
+              _buildNavItem(2, Symbols.home, '홈'),
+              _buildNavItem(3, Symbols.star, '관심'),
+              _buildNavItem(4, Symbols.person, '프로필'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNavItem(int index, IconData icon, String label) {
+    final isSelected = currentIndex == index;
+    final color = isSelected ? CustomColor.white : CustomColor.gray600;
+
+    return GestureDetector(
+      onTap: () => onTap(index),
+      child: SizedBox(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, color: color, size: 22, fill: isSelected ? 1.0 : 0.0),
+            const SizedBox(height: 4),
+            Text(label, style: CustomTextStyle.body2.copyWith(color: color)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/components/bottom_nav/twelfth_bottom_nav_bar.dart
+++ b/lib/common/components/bottom_nav/twelfth_bottom_nav_bar.dart
@@ -16,7 +16,10 @@ class TwelfthBottomNavBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      decoration: const BoxDecoration(color: CustomColor.background),
+      decoration: const BoxDecoration(
+        color: CustomColor.background,
+        border: Border(top: BorderSide(color: CustomColor.gray900, width: 1)),
+      ),
       child: SafeArea(
         child: SizedBox(
           height: 56,
@@ -41,6 +44,7 @@ class TwelfthBottomNavBar extends StatelessWidget {
 
     return GestureDetector(
       onTap: () => onTap(index),
+      behavior: HitTestBehavior.opaque,
       child: SizedBox(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
<img width="357" height="90" alt="image" src="https://github.com/user-attachments/assets/0e82d33a-45fc-455d-9e16-590f391dbf83" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bottom navigation bar with five tabs (랭킹 / 검색 / 홈 / 관심 / 프로필). Each tab shows an icon and label, highlights the selected tab in white while unselected tabs appear gray, supports tap interaction to change selection, and uses a safe, consistently spaced layout for clear navigation feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->