### PR TITLE
feat: 구단 및 선수 검색 연동

### DIFF
--- a/lib/features/search/data/datasources/search_remote_datasource.dart
+++ b/lib/features/search/data/datasources/search_remote_datasource.dart
@@ -20,17 +20,22 @@ class SearchRemoteDataSourceImpl implements ISearchRemoteDataSource {
     return rawData as Map<String, dynamic>;
   }
 
+  void _logDebug(String message) {
+    assert(() {
+      developer.log(message, name: 'SearchRemoteDataSource');
+      return true;
+    }());
+  }
+
   @override
   Future<List<ClubSearchResultModel>> searchClubs(String keyword) async {
     try {
-      developer.log('[Search] 구단 검색: keyword=$keyword');
+      _logDebug('[Search] 구단 검색 요청');
       final response = await _dio.get(
         ApiEndpoints.clubSearch,
         queryParameters: {'keyword': keyword},
       );
-      developer.log(
-        '[Search] 구단 검색 응답 status: ${response.statusCode} | data: ${response.data}',
-      );
+      _logDebug('[Search] 구단 검색 응답 status: ${response.statusCode}');
       final data = _parseMap(response.data);
       final list =
           (data['clubs'] as List<dynamic>?) ??
@@ -40,8 +45,8 @@ class SearchRemoteDataSourceImpl implements ISearchRemoteDataSource {
           .map((e) => ClubSearchResultModel.fromJson(e as Map<String, dynamic>))
           .toList();
     } on DioException catch (e) {
-      developer.log(
-        '[Search] 구단 검색 실패 (DioException)\n  type: ${e.type}\n  status: ${e.response?.statusCode}\n  message: ${e.message}\n  error: ${e.error}\n  URL: ${e.requestOptions.uri}\n  response: ${e.response?.data}',
+      _logDebug(
+        '[Search] 구단 검색 실패 type=${e.type} status=${e.response?.statusCode} path=${e.requestOptions.path}',
       );
       rethrow;
     } catch (e, stack) {

--- a/lib/features/search/data/datasources/search_remote_datasource.dart
+++ b/lib/features/search/data/datasources/search_remote_datasource.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:developer' as developer;
+import 'package:dio/dio.dart';
+import 'package:twelfth_mobile/core/network/api_endpoints.dart';
+import 'package:twelfth_mobile/features/search/data/models/search_models.dart';
+
+abstract interface class ISearchRemoteDataSource {
+  Future<List<ClubSearchResultModel>> searchClubs(String keyword);
+
+  Future<List<PlayerSearchResultModel>> searchPlayers(String keyword);
+}
+
+class SearchRemoteDataSourceImpl implements ISearchRemoteDataSource {
+  final Dio _dio;
+
+  const SearchRemoteDataSourceImpl(this._dio);
+
+  Map<String, dynamic> _parseMap(dynamic rawData) {
+    if (rawData is String) return jsonDecode(rawData) as Map<String, dynamic>;
+    return rawData as Map<String, dynamic>;
+  }
+
+  @override
+  Future<List<ClubSearchResultModel>> searchClubs(String keyword) async {
+    try {
+      developer.log('[Search] 구단 검색: keyword=$keyword');
+      final response = await _dio.get(
+        ApiEndpoints.clubSearch,
+        queryParameters: {'keyword': keyword},
+      );
+      developer.log(
+        '[Search] 구단 검색 응답 status: ${response.statusCode} | data: ${response.data}',
+      );
+      final data = _parseMap(response.data);
+      final list =
+          (data['clubs'] as List<dynamic>?) ??
+          (data['content'] as List<dynamic>?) ??
+          [];
+      return list
+          .map((e) => ClubSearchResultModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      developer.log(
+        '[Search] 구단 검색 실패 (DioException)\n  type: ${e.type}\n  status: ${e.response?.statusCode}\n  message: ${e.message}\n  error: ${e.error}\n  URL: ${e.requestOptions.uri}\n  response: ${e.response?.data}',
+      );
+      rethrow;
+    } catch (e, stack) {
+      developer.log('[Search] 구단 검색 실패 (Exception)\n  $e\n$stack');
+      rethrow;
+    }
+  }
+
+  @override
+  Future<List<PlayerSearchResultModel>> searchPlayers(String keyword) async {
+    try {
+      developer.log('[Search] 선수 검색: keyword=$keyword');
+      final response = await _dio.get(
+        ApiEndpoints.playerSearch,
+        queryParameters: {'keyword': keyword},
+      );
+      developer.log(
+        '[Search] 선수 검색 응답 status: ${response.statusCode} | data: ${response.data}',
+      );
+      final data = _parseMap(response.data);
+      final list = (data['content'] as List<dynamic>?) ?? [];
+      return list
+          .map(
+            (e) => PlayerSearchResultModel.fromJson(e as Map<String, dynamic>),
+          )
+          .toList();
+    } on DioException catch (e) {
+      developer.log(
+        '[Search] 선수 검색 실패 (DioException)\n  type: ${e.type}\n  status: ${e.response?.statusCode}\n  message: ${e.message}\n  error: ${e.error}\n  URL: ${e.requestOptions.uri}\n  response: ${e.response?.data}',
+      );
+      rethrow;
+    } catch (e, stack) {
+      developer.log('[Search] 선수 검색 실패 (Exception)\n  $e\n$stack');
+      rethrow;
+    }
+  }
+}

--- a/lib/features/search/data/models/search_models.dart
+++ b/lib/features/search/data/models/search_models.dart
@@ -1,0 +1,64 @@
+import 'package:twelfth_mobile/constants/team_name_map.dart';
+import 'package:twelfth_mobile/features/search/domain/entities/club_search_result.dart';
+import 'package:twelfth_mobile/features/search/domain/entities/player_search_result.dart';
+
+class ClubSearchResultModel {
+  final int clubId;
+  final String name;
+  final String? logoUrl;
+
+  const ClubSearchResultModel({
+    required this.clubId,
+    required this.name,
+    this.logoUrl,
+  });
+
+  factory ClubSearchResultModel.fromJson(Map<String, dynamic> json) =>
+      ClubSearchResultModel(
+        clubId: json['clubId'] as int,
+        name: TeamNameMap.translate(
+          (json['clubName'] ?? json['name']) as String,
+        ),
+        logoUrl: json['logoUrl'] as String?,
+      );
+
+  ClubSearchResult toEntity() =>
+      ClubSearchResult(clubId: clubId, name: name, logoUrl: logoUrl);
+}
+
+class PlayerSearchResultModel {
+  final int playerId;
+  final String name;
+  final int? age;
+  final String? position;
+  final int? number;
+  final String? clubName;
+
+  const PlayerSearchResultModel({
+    required this.playerId,
+    required this.name,
+    this.age,
+    this.position,
+    this.number,
+    this.clubName,
+  });
+
+  factory PlayerSearchResultModel.fromJson(Map<String, dynamic> json) =>
+      PlayerSearchResultModel(
+        playerId: json['playerId'] as int,
+        name: json['name'] as String,
+        age: json['age'] as int?,
+        position: json['position'] as String?,
+        number: json['number'] as int?,
+        clubName: json['clubName'] as String?,
+      );
+
+  PlayerSearchResult toEntity() => PlayerSearchResult(
+    playerId: playerId,
+    name: name,
+    age: age,
+    position: position,
+    number: number,
+    clubName: clubName,
+  );
+}

--- a/lib/features/search/data/repositories/search_repository_impl.dart
+++ b/lib/features/search/data/repositories/search_repository_impl.dart
@@ -1,0 +1,22 @@
+import 'package:twelfth_mobile/features/search/data/datasources/search_remote_datasource.dart';
+import 'package:twelfth_mobile/features/search/domain/entities/club_search_result.dart';
+import 'package:twelfth_mobile/features/search/domain/entities/player_search_result.dart';
+import 'package:twelfth_mobile/features/search/domain/repositories/i_search_repository.dart';
+
+class SearchRepositoryImpl implements ISearchRepository {
+  final ISearchRemoteDataSource _dataSource;
+
+  const SearchRepositoryImpl(this._dataSource);
+
+  @override
+  Future<List<ClubSearchResult>> searchClubs(String keyword) async {
+    final models = await _dataSource.searchClubs(keyword);
+    return models.map((m) => m.toEntity()).toList();
+  }
+
+  @override
+  Future<List<PlayerSearchResult>> searchPlayers(String keyword) async {
+    final models = await _dataSource.searchPlayers(keyword);
+    return models.map((m) => m.toEntity()).toList();
+  }
+}

--- a/lib/features/search/domain/entities/club_search_result.dart
+++ b/lib/features/search/domain/entities/club_search_result.dart
@@ -1,0 +1,11 @@
+class ClubSearchResult {
+  final int clubId;
+  final String name;
+  final String? logoUrl;
+
+  const ClubSearchResult({
+    required this.clubId,
+    required this.name,
+    this.logoUrl,
+  });
+}

--- a/lib/features/search/domain/entities/player_search_result.dart
+++ b/lib/features/search/domain/entities/player_search_result.dart
@@ -1,0 +1,17 @@
+class PlayerSearchResult {
+  final int playerId;
+  final String name;
+  final int? age;
+  final String? position;
+  final int? number;
+  final String? clubName;
+
+  const PlayerSearchResult({
+    required this.playerId,
+    required this.name,
+    this.age,
+    this.position,
+    this.number,
+    this.clubName,
+  });
+}

--- a/lib/features/search/domain/repositories/i_search_repository.dart
+++ b/lib/features/search/domain/repositories/i_search_repository.dart
@@ -1,0 +1,8 @@
+import 'package:twelfth_mobile/features/search/domain/entities/club_search_result.dart';
+import 'package:twelfth_mobile/features/search/domain/entities/player_search_result.dart';
+
+abstract interface class ISearchRepository {
+  Future<List<ClubSearchResult>> searchClubs(String keyword);
+
+  Future<List<PlayerSearchResult>> searchPlayers(String keyword);
+}

--- a/lib/features/search/domain/usecases/search_usecases.dart
+++ b/lib/features/search/domain/usecases/search_usecases.dart
@@ -1,0 +1,21 @@
+import 'package:twelfth_mobile/features/search/domain/entities/club_search_result.dart';
+import 'package:twelfth_mobile/features/search/domain/entities/player_search_result.dart';
+import 'package:twelfth_mobile/features/search/domain/repositories/i_search_repository.dart';
+
+class SearchClubsUseCase {
+  final ISearchRepository _repository;
+
+  const SearchClubsUseCase(this._repository);
+
+  Future<List<ClubSearchResult>> call(String keyword) =>
+      _repository.searchClubs(keyword);
+}
+
+class SearchPlayersUseCase {
+  final ISearchRepository _repository;
+
+  const SearchPlayersUseCase(this._repository);
+
+  Future<List<PlayerSearchResult>> call(String keyword) =>
+      _repository.searchPlayers(keyword);
+}

--- a/lib/features/search/presentation/providers/search_provider.dart
+++ b/lib/features/search/presentation/providers/search_provider.dart
@@ -1,0 +1,98 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:twelfth_mobile/core/network/dio.dart';
+import 'package:twelfth_mobile/features/search/data/datasources/search_remote_datasource.dart';
+import 'package:twelfth_mobile/features/search/data/repositories/search_repository_impl.dart';
+import 'package:twelfth_mobile/features/search/domain/repositories/i_search_repository.dart';
+import 'package:twelfth_mobile/features/search/domain/usecases/search_usecases.dart';
+import 'package:twelfth_mobile/features/search/presentation/providers/search_state.dart';
+
+final _dioProvider = Provider<Dio>((ref) => DioClient.instance.dio);
+
+final _searchRemoteDataSourceProvider = Provider<ISearchRemoteDataSource>(
+  (ref) => SearchRemoteDataSourceImpl(ref.read(_dioProvider)),
+);
+
+final searchRepositoryProvider = Provider<ISearchRepository>(
+  (ref) => SearchRepositoryImpl(ref.read(_searchRemoteDataSourceProvider)),
+);
+
+final _searchClubsUseCaseProvider = Provider<SearchClubsUseCase>(
+  (ref) => SearchClubsUseCase(ref.read(searchRepositoryProvider)),
+);
+
+final _searchPlayersUseCaseProvider = Provider<SearchPlayersUseCase>(
+  (ref) => SearchPlayersUseCase(ref.read(searchRepositoryProvider)),
+);
+
+class SearchNotifier extends Notifier<SearchState> {
+  @override
+  SearchState build() => const SearchState();
+
+  void setFilter(SearchFilter filter) {
+    state = state.copyWith(
+      filter: filter,
+      status: SearchStatus.initial,
+      clubs: [],
+      players: [],
+    );
+  }
+
+  Future<void> search(String keyword) async {
+    final q = keyword.trim();
+    if (q.isEmpty) {
+      state = state.copyWith(
+        status: SearchStatus.initial,
+        clubs: [],
+        players: [],
+      );
+      return;
+    }
+
+    state = state.copyWith(status: SearchStatus.loading);
+
+    try {
+      if (state.filter == SearchFilter.club) {
+        final clubs = await ref.read(_searchClubsUseCaseProvider).call(q);
+        state = clubs.isEmpty
+            ? state.copyWith(status: SearchStatus.empty, clubs: [])
+            : state.copyWith(status: SearchStatus.success, clubs: clubs);
+      } else {
+        final players = await ref.read(_searchPlayersUseCaseProvider).call(q);
+        state = players.isEmpty
+            ? state.copyWith(status: SearchStatus.empty, players: [])
+            : state.copyWith(status: SearchStatus.success, players: players);
+      }
+    } on DioException catch (e) {
+      state = state.copyWith(
+        status: SearchStatus.error,
+        errorMessage: _parseError(e),
+      );
+    }
+  }
+
+  void reset() {
+    state = SearchState(filter: state.filter);
+  }
+
+  String _parseError(DioException e) {
+    switch (e.response?.statusCode) {
+      case 400:
+        return '해당 키워드가 없습니다';
+      case 403:
+        return '권한이 없습니다';
+      case 404:
+        return '결과를 찾을 수 없습니다';
+      default:
+        if (e.type == DioExceptionType.connectionTimeout ||
+            e.type == DioExceptionType.receiveTimeout) {
+          return '네트워크 연결을 확인해 주세요';
+        }
+        return '오류가 발생했습니다. 다시 시도해 주세요';
+    }
+  }
+}
+
+final searchNotifierProvider = NotifierProvider<SearchNotifier, SearchState>(
+  SearchNotifier.new,
+);

--- a/lib/features/search/presentation/providers/search_provider.dart
+++ b/lib/features/search/presentation/providers/search_provider.dart
@@ -26,6 +26,8 @@ final _searchPlayersUseCaseProvider = Provider<SearchPlayersUseCase>(
 );
 
 class SearchNotifier extends Notifier<SearchState> {
+  int _requestId = 0;
+
   @override
   SearchState build() => const SearchState();
 
@@ -33,16 +35,19 @@ class SearchNotifier extends Notifier<SearchState> {
     state = state.copyWith(
       filter: filter,
       status: SearchStatus.initial,
+      errorMessage: null,
       clubs: [],
       players: [],
     );
   }
 
   Future<void> search(String keyword) async {
+    final requestId = ++_requestId;
     final q = keyword.trim();
     if (q.isEmpty) {
       state = state.copyWith(
         status: SearchStatus.initial,
+        errorMessage: null,
         clubs: [],
         players: [],
       );
@@ -54,11 +59,13 @@ class SearchNotifier extends Notifier<SearchState> {
     try {
       if (state.filter == SearchFilter.club) {
         final clubs = await ref.read(_searchClubsUseCaseProvider).call(q);
+        if (requestId != _requestId) return;
         state = clubs.isEmpty
             ? state.copyWith(status: SearchStatus.empty, clubs: [])
             : state.copyWith(status: SearchStatus.success, clubs: clubs);
       } else {
         final players = await ref.read(_searchPlayersUseCaseProvider).call(q);
+        if (requestId != _requestId) return;
         state = players.isEmpty
             ? state.copyWith(status: SearchStatus.empty, players: [])
             : state.copyWith(status: SearchStatus.success, players: players);
@@ -72,7 +79,7 @@ class SearchNotifier extends Notifier<SearchState> {
   }
 
   void reset() {
-    state = SearchState(filter: state.filter);
+    state = SearchState(filter: state.filter, errorMessage: null);
   }
 
   String _parseError(DioException e) {

--- a/lib/features/search/presentation/providers/search_state.dart
+++ b/lib/features/search/presentation/providers/search_state.dart
@@ -1,0 +1,42 @@
+import 'package:twelfth_mobile/features/search/domain/entities/club_search_result.dart';
+import 'package:twelfth_mobile/features/search/domain/entities/player_search_result.dart';
+
+enum SearchStatus { initial, loading, success, empty, error }
+
+enum SearchFilter { player, club }
+
+class SearchState {
+  final SearchStatus status;
+  final SearchFilter filter;
+  final List<ClubSearchResult> clubs;
+  final List<PlayerSearchResult> players;
+  final String? errorMessage;
+
+  const SearchState({
+    this.status = SearchStatus.initial,
+    this.filter = SearchFilter.player,
+    this.clubs = const [],
+    this.players = const [],
+    this.errorMessage,
+  });
+
+  bool get isLoading => status == SearchStatus.loading;
+
+  bool get hasResults =>
+      status == SearchStatus.success &&
+      (clubs.isNotEmpty || players.isNotEmpty);
+
+  SearchState copyWith({
+    SearchStatus? status,
+    SearchFilter? filter,
+    List<ClubSearchResult>? clubs,
+    List<PlayerSearchResult>? players,
+    String? errorMessage,
+  }) => SearchState(
+    status: status ?? this.status,
+    filter: filter ?? this.filter,
+    clubs: clubs ?? this.clubs,
+    players: players ?? this.players,
+    errorMessage: errorMessage,
+  );
+}

--- a/lib/features/search/presentation/providers/search_state.dart
+++ b/lib/features/search/presentation/providers/search_state.dart
@@ -6,6 +6,7 @@ enum SearchStatus { initial, loading, success, empty, error }
 enum SearchFilter { player, club }
 
 class SearchState {
+  static const Object _noChange = Object();
   final SearchStatus status;
   final SearchFilter filter;
   final List<ClubSearchResult> clubs;
@@ -31,12 +32,14 @@ class SearchState {
     SearchFilter? filter,
     List<ClubSearchResult>? clubs,
     List<PlayerSearchResult>? players,
-    String? errorMessage,
+    Object? errorMessage = _noChange,
   }) => SearchState(
     status: status ?? this.status,
     filter: filter ?? this.filter,
     clubs: clubs ?? this.clubs,
     players: players ?? this.players,
-    errorMessage: errorMessage,
+    errorMessage: identical(errorMessage, _noChange)
+        ? this.errorMessage
+        : errorMessage as String?,
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyword search for clubs and players with results listing
  * Filter toggle to switch between club and player results
  * Results include club names, logos and basic player details (age, position, number, club)
  * Search status indicators: loading, success, empty, error
  * User-facing error messages for network/timeouts and failed searches
  * Reset/search clearing to restore initial state and ignore stale results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->